### PR TITLE
bumping docker base image from jessie to the latest praekelt django docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,8 @@
-FROM praekeltfoundation/django-bootstrap:py3.6-jessie
-RUN apt-get-install.sh git \
-    redis-server supervisor libpq-dev gcc && \
-    ln -s /usr/bin/nodejs /usr/bin/node
+FROM praekeltfoundation/django-bootstrap:latest
 
 #Upgrade Nodejs to v4.9 as the current version v4.6 doesn't appear to have support for object.assign 
 #Check https://node.green for compatibility
-RUN apt-get update && apt-get install curl -y && curl -sL https://deb.nodesource.com/setup_4.x | bash && apt-get install nodejs -y
+RUN apt-get update && apt-get install git redis-server supervisor libpq-dev gcc curl -y && curl -sL https://deb.nodesource.com/setup_4.x | bash && apt-get install nodejs -y && apt-get autoremove -y && apt-get clean
 
 ENV DJANGO_SETTINGS_MODULE "casepro.settings_production"
 ENV APP_MODULE "casepro.wsgi:application"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM praekeltfoundation/django-bootstrap:latest
+FROM praekeltfoundation/django-bootstrap:py3.6-stretch
 
 #Upgrade Nodejs to v4.9 as the current version v4.6 doesn't appear to have support for object.assign 
 #Check https://node.green for compatibility
-RUN apt-get update && apt-get install git redis-server supervisor libpq-dev gcc curl -y && curl -sL https://deb.nodesource.com/setup_4.x | bash && apt-get install nodejs -y && apt-get autoremove -y && apt-get clean
+RUN apt-get update && apt-get-install.sh git redis-server supervisor libpq-dev gcc curl -y && curl -sL https://deb.nodesource.com/setup_4.x | bash && apt-get install nodejs -y
 
 ENV DJANGO_SETTINGS_MODULE "casepro.settings_production"
 ENV APP_MODULE "casepro.wsgi:application"


### PR DESCRIPTION
Currently the Docker image won't build. See #227.

This PR fixes the build and streamlines it a bit: should end up with a smaller image due to combining all apt-get into a single line and running `apt-get clean` and `apt-get autoremove`.
