### PR TITLE
Change /var/run to /run

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,7 +1,7 @@
 upstream gunicorn {
     # Proxy to Gunicorn socket and always retry, as recommended by deployment
     # guide: http://docs.gunicorn.org/en/stable/deploy.html
-    server unix:/var/run/gunicorn/gunicorn.sock max_fails=0;
+    server unix:/run/gunicorn/gunicorn.sock max_fails=0;
 }
 
 server {

--- a/docker/supervisor.conf
+++ b/docker/supervisor.conf
@@ -1,5 +1,5 @@
 [program:web]
-command = gunicorn casepro.wsgi:application --timeout 1800 --workers 2 --bind unix:/var/run/gunicorn/gunicorn.sock
+command = gunicorn casepro.wsgi:application --timeout 1800 --workers 2 --bind unix:/run/gunicorn/gunicorn.sock
 directory = /app/
 redirect_stderr = true
 

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -1,19 +1,19 @@
 ; supervisor config file
 
 [unix_http_server]
-file=/var/run/supervisor.sock   ; (the path to the socket file)
+file=/run/supervisor.sock   ; (the path to the socket file)
 chmod=0700                      ; sockef file mode (default 0700)
 
 [supervisord]
 logfile=/var/log/supervisor/supervisord.log ; (main log file;default $CWD/supervisord.log)
-pidfile=/var/run/supervisord.pid ; (supervisord pidfile;default supervisord.pid)
+pidfile=/run/supervisord.pid ; (supervisord pidfile;default supervisord.pid)
 childlogdir=/var/log/supervisor            ; ('AUTO' child log dir, default $TEMP)
 
 [rpcinterface:supervisor]
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
 [supervisorctl]
-serverurl=unix:///var/run/supervisor.sock ; use a unix:// URL  for a unix socket
+serverurl=unix:///run/supervisor.sock ; use a unix:// URL  for a unix socket
 
 [include]
 files = /etc/supervisor/conf.d/*.conf


### PR DESCRIPTION
Django bootstrap has changed the folder from `/var/run` to just `/run`, so we need to change it here in our config as well